### PR TITLE
#168402459 View related articles when reading an article

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -13,8 +13,11 @@ import PasswordResetForm from '@Views/passwordReset/NewPassword';
 import LandingPage from '@Views/landingPage/LandingPage';
 import Article from '@Views/article/Article';
 import ContainerWrapper from '@Common/hoc/ContainerWrapper';
+import setUser from '@Utils/setUser';
 import store from './redux/store';
 import './app.scss';
+
+setUser();
 
 const App = () => (
   <Provider store={store}>

--- a/src/components/views/article/Article.js
+++ b/src/components/views/article/Article.js
@@ -8,6 +8,10 @@ import Tag from '@Common/tags/Tag';
 import ArticleComment from '@Common/comments/ArticleComment';
 import Loader from '@Common/loader/Loader';
 import parseDataFromJSON from '@Utils/parseEditorData';
+import Card from '@Common/landingPage/card/Cards';
+import isEmpty from '@Utils/isEmpty';
+import readTimeFunc from '@Utils/readTime';
+
 import './article.scss';
 
 const Article = ({
@@ -16,6 +20,7 @@ const Article = ({
   singleArticle,
   loading,
   error,
+  relatedArticles,
 }) => {
   useEffect(() => {
     const getArticle = async () => {
@@ -23,8 +28,8 @@ const Article = ({
     };
 
     getArticle();
+    window.scrollTo(0, 0);
   }, [match, fetchSingleArticleBySlug]);
-
   return (
     <Fragment>
       <div className="article__container">
@@ -52,7 +57,7 @@ const Article = ({
               </div>
             </div>
             <div className="article__content">
-              <p className="article__read__time">{singleArticle.readTime} Min Read</p>
+              <p className="article__read__time">{readTimeFunc(singleArticle.readTime)}</p>
               <h1 className="article__title">{singleArticle.title}</h1>
               <p className="article__description">
                 {singleArticle.description}
@@ -86,6 +91,22 @@ const Article = ({
               <ArticleComment />
               <div className="article__related__articles">
                 <h3>Related Articles</h3>
+                <div className="article__divider" />
+                <div className="related__article__container">
+                  {
+                  !isEmpty(relatedArticles) ? relatedArticles.map((related) => {
+                    if (related.id !== singleArticle.id) {
+                      return (
+                        <Card
+                          key={related.id}
+                          {...related}
+                        />
+                      );
+                    }
+                    return null;
+                  }) : <h2>There are currently no related articles to this article</h2>
+                }
+                </div>
               </div>
             </div>
           </div>
@@ -102,17 +123,20 @@ Article.propTypes = {
   singleArticle: PropTypes.shape({}),
   error: PropTypes.shape({}),
   loading: PropTypes.bool.isRequired,
+  relatedArticles: PropTypes.shape([]),
 };
 
 Article.defaultProps = {
   singleArticle: {},
   error: {},
+  relatedArticles: [],
 };
 
 const mapStateToProps = state => ({
   singleArticle: state.singleArticle.article,
   loading: state.singleArticle.loading,
   error: state.singleArticle.error,
+  relatedArticles: state.singleArticle.article.relatedArticles,
 });
 
 export const ArticleComponent = Article;

--- a/src/components/views/article/article.scss
+++ b/src/components/views/article/article.scss
@@ -109,6 +109,12 @@
           padding: 1rem;
         }
 
+        h1 {
+          font-size: 4rem;
+          font-weight: 500;
+          margin-top: 3rem;
+        }
+
       }
 
       div.article__tags {
@@ -149,6 +155,51 @@
     .article__related__articles {
       h3 {
         text-align: center;
+      }
+
+      .related__article__container {
+        display: flex;
+        flex-direction: row;
+        margin-top: 2.5rem;
+        margin-bottom: 3.5rem;
+        flex-flow: row wrap;
+        justify-content: space-between;
+        @media only screen and (max-width: 425px) {
+            width: 100%;
+            margin-left: -2.5rem !important;
+        }
+
+        .article-card {
+          margin-right: 0 !important;
+        }
+
+        p {
+          margin: 0;
+        }
+
+        @media only screen and (max-width: 425px) {
+  
+          .article-card {
+            width: 100%;
+            margin-left: -5rem !important;
+          }
+        }
+
+        @media only screen and (max-width: 768px) {
+  
+          .article-card {
+            width: 100%;
+            margin-left: 4rem !important;
+          }
+        }
+
+        @media only screen and (max-width: 1024px) {
+  
+          .article-card {
+            width: 100%;
+            margin-left: 7rem;
+          }
+        }
       }
     }
   }

--- a/src/redux/actions/articleActions.js
+++ b/src/redux/actions/articleActions.js
@@ -1,5 +1,6 @@
 
 import API_SERVICE from '@Utils/API';
+import isEmpty from '@Utils/isEmpty';
 import {
   GET_ARTICLES,
   GET_ARTICLE_ERROR,
@@ -44,8 +45,14 @@ export const getArticleBySlug = slug => async (dispatch) => {
   dispatch(clearArticleError());
   dispatch(articleLoading());
   try {
-    const fetchArticle = await API_SERVICE.get(`/articles/${slug}`);
-    dispatch(getSingleArticle(fetchArticle.data.article));
+    const fetchedArticle = await API_SERVICE.get(`/articles/${slug}`);
+    const { tagsList } = fetchedArticle.data.article;
+    if (!isEmpty(tagsList)) {
+      const randomTag = tagsList[Math.floor(Math.random() * tagsList.length)];
+      const relatedArticles = await API_SERVICE.get(`/search?keyword=${randomTag}`);
+      fetchedArticle.data.article.relatedArticles = relatedArticles.data.matches.tags;
+    }
+    dispatch(getSingleArticle(fetchedArticle.data.article));
   } catch (error) {
     dispatch(articleError(error.response.data.errors));
   }

--- a/src/redux/actions/articleActions.spec.js
+++ b/src/redux/actions/articleActions.spec.js
@@ -22,9 +22,6 @@ const articleResponse = {
   slug: 'getting-started-with-nodejs-&-express-1564498223366-74536',
   body: 'Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Porttitor leo a diam sollicitudin tempor id eu. Dolor sit amet consectetur adipiscing. Vitae semper quis lectus nulla at volutpat diam ut. Elementum curabitur vitae nunc sed velit dignissim sodales ut. Nunc sed blandit libero volutpat. In egestas erat imperdiet sed euismod. Neque convallis a cras semper auctor neque vitae tempus. Dignissim cras tincidunt lobortis feugiat vivamus at augue eget. Metus vulputate eu scelerisque felis imperdiet proin fermentum leo vel. Lacus vel facilisis volutpat est velit egestas dui id. Non nisi est sit amet facilisis magna. Pulvinar sapien et ligula ullamcorper malesuada. Ipsum consequat nisl vel pretium. Elit eget gravida cum sociis. Lacinia at quis risus sed vulputate odio ut. Laoreet non curabitur gravida arcu. Dictumst vestibulum rhoncus est pellentesque elit ullamcorper. Magna fringilla urna porttitor rhoncus dolor. Amet dictum sit amet justo donec enim diam vulputate ut. Sit amet est placerat in.',
   tagsList: [
-    'technology',
-    'NodeJS',
-    'Express',
   ],
   status: 'published',
   userId: '10ba038e-48da-487b-96e8-8d3b99b6d18a',
@@ -45,6 +42,7 @@ const articleResponse = {
       updatedAt: 'Unknown Type: date',
     },
   },
+  relatedArticles: [],
 };
 
 jest.mock('axios');

--- a/utils/isEmpty.js
+++ b/utils/isEmpty.js
@@ -1,0 +1,8 @@
+const isEmpty = value => (
+  value === undefined
+    || value === null
+    || (typeof value === 'object' && Object.keys(value).length === 0)
+    || (typeof value === 'string' && value.trim().length === 0)
+);
+
+export default isEmpty;

--- a/utils/setUser.js
+++ b/utils/setUser.js
@@ -1,0 +1,19 @@
+/* eslint-disable no-return-assign */
+import jwtDecode from 'jwt-decode';
+import store from '@Redux/store';
+import { authSuccess, logoutAccount } from '@Actions/authActions';
+
+const setUser = () => {
+  if (localStorage.jwtToken) {
+    const decoded = jwtDecode(localStorage.jwtToken);
+    store.dispatch(authSuccess(decoded));
+
+    const currentTime = Date.now() / 1000;
+    if (decoded.exp < currentTime) {
+      const history = { push: () => window.location.href = '/signin' };
+      store.dispatch(logoutAccount(history));
+    }
+  }
+};
+
+export default setUser;


### PR DESCRIPTION
### What does this PR do?
Creates components to view related articles when viewing a single article
Fixes issue where the authentication state does not persist if the app is refreshed

#### Description of Task to be completed?
When a user is viewing/reading an article they should be able to see other articles related to it below the article.

#### How should this be manually tested?
You can the review app created by this PR

To run it locally;

After cloning this repo, `cd` into it and do the following:

```bash
# fetch this branch
$ git fetch origin bg-fix-view-related-articles-168402459

# install dependencies
$ npm install

# unit and integration tests are available by running this script
$ npm test

# start the development server
$ npm run dev
```

After doing this, you should see a message appear on the console, with the app running on Port 8080, you can view the app on `localhost:8080`

#### Any background context you want to provide?
N/a

#### What are the relevant pivotal tracker stories?
[ #168402459](https://www.pivotaltracker.com/story/show/168402459)

#### Screenshots (if appropriate)
<img width="1680" alt="Screenshot 2019-09-10 at 2 12 11 PM" src="https://user-images.githubusercontent.com/42325628/64619380-e41d4c00-d3d9-11e9-89c9-410c8257cd07.png">
